### PR TITLE
measurement: network-connected devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "netrics", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-fate-scheduler = "0.1.0-rc.8"
+fate-scheduler = "0.1.0-rc.9"
 netifaces = "^0.11.0"
 
 [tool.poetry.dev-dependencies]

--- a/src/netrics/conf/include/measurements.yaml
+++ b/src/netrics/conf/include/measurements.yaml
@@ -1,3 +1,6 @@
+dev:
+  schedule: "H/5 * * * *"
+
 dns-latency:
   schedule: "H/5 * * * *"
   param:

--- a/src/netrics/task/__init__.py
+++ b/src/netrics/task/__init__.py
@@ -1,4 +1,4 @@
-from fate.task import log  # noqa: F401
+from fate.task import log, state  # noqa: F401
 
 from . import (  # noqa: F401
     param,


### PR DESCRIPTION
Report (and record) network-connected devices.
    
Adds measurement `dev` (executable `netrics-dev`) to scan local network and report on the number of connected devices.
    
Notably, this change implements Fate task state persistence, applied to this measurement.